### PR TITLE
Don't show unknown StepExecution

### DIFF
--- a/rest/src/main/java/org/seedstack/batch/monitoring/rest/stepexecution/StepExecutionResource.java
+++ b/rest/src/main/java/org/seedstack/batch/monitoring/rest/stepexecution/StepExecutionResource.java
@@ -54,9 +54,11 @@ public class StepExecutionResource {
         try {
             for (StepExecution stepExecution : jobService
                     .getStepExecutions(jobExecutionId)) {
-                stepExecutionRepresentations
-                        .add(new StepExecutionRepresentation(stepExecution,
-                                TimeZone.getTimeZone("GMT")));
+                if (stepExecution.getId() != null) {
+                    stepExecutionRepresentations
+                            .add(new StepExecutionRepresentation(stepExecution,
+                                    TimeZone.getTimeZone("GMT")));
+                }
             }
 
         } catch (NoSuchJobExecutionException e) {


### PR DESCRIPTION
To avoid IllegalArgumentException to be thrown, StepExecutionRepresentation shouldn't be created with an unknown StepExecution.
